### PR TITLE
chore: add free security baseline

### DIFF
--- a/.github/scripts/repository_policy_scan.py
+++ b/.github/scripts/repository_policy_scan.py
@@ -1,0 +1,83 @@
+"""Fail safely on tracked secret containers and high-confidence PII.
+
+Only file paths and rule identifiers are printed; matched values never leave the runner.
+"""
+from __future__ import annotations
+import re
+import subprocess
+from pathlib import Path, PurePosixPath
+
+ROOT = Path.cwd()
+MAX_TEXT_BYTES = 2_000_000
+TEXT_SUFFIXES = {
+    ".c", ".cpp", ".cs", ".css", ".csv", ".env", ".go", ".h", ".html",
+    ".java", ".js", ".json", ".jsx", ".md", ".mjs", ".py", ".rs", ".sql",
+    ".toml", ".ts", ".tsx", ".txt", ".xml", ".yaml", ".yml",
+}
+RISKY_SUFFIXES = {".bak", ".bundle", ".dump", ".jks", ".key", ".keystore", ".p12", ".pem", ".pfx"}
+SAFE_ENV_NAMES = {".env.example", ".env.sample", ".env.template"}
+SYNTHETIC_EMAIL_DOMAINS = {"example.com", "example.invalid", "example.org", "test.invalid"}
+EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b")
+CPF_RE = re.compile(r"(?<!\d)(\d{3})[.\s-]?(\d{3})[.\s-]?(\d{3})[-\s]?(\d{2})(?!\d)")
+PHONE_RE = re.compile(
+    r"(?<!\d)(?:(?:\+?55[\s.-]+\(?[1-9]{2}\)?)|(?:\([1-9]{2}\)))[\s.-]+9?\d{4}[\s.-]?\d{4}(?!\d)"
+)
+SENSITIVE_CONTEXT = re.compile(r"(?i)(seed|fixture|snapshot|dump|backup|bundle|credential|customer|user)")
+
+def tracked_files() -> list[str]:
+    raw = subprocess.check_output(["git", "ls-files", "-z"])
+    return [item.decode("utf-8", errors="surrogateescape") for item in raw.split(b"\0") if item]
+
+def valid_cpf(raw: str) -> bool:
+    digits = re.sub(r"\D", "", raw)
+    if len(digits) != 11 or len(set(digits)) == 1:
+        return False
+    for length in (9, 10):
+        total = sum(int(digit) * weight for digit, weight in zip(digits[:length], range(length + 1, 1, -1)))
+        check = (total * 10) % 11
+        if check == 10:
+            check = 0
+        if check != int(digits[length]):
+            return False
+    return True
+
+def main() -> None:
+    findings: set[tuple[str, str]] = set()
+    for item in tracked_files():
+        posix = PurePosixPath(item)
+        name = posix.name.lower()
+        suffix = posix.suffix.lower()
+        if name.startswith(".env") and name not in SAFE_ENV_NAMES:
+            findings.add((item, "tracked-env-file"))
+        if suffix in RISKY_SUFFIXES or (name.endswith((".sql.gz", ".tar.gz")) and SENSITIVE_CONTEXT.search(item)):
+            findings.add((item, "risky-secret-container"))
+        path = ROOT / Path(item)
+        try:
+            if not path.is_file() or path.stat().st_size > MAX_TEXT_BYTES:
+                continue
+            if suffix not in TEXT_SUFFIXES and name not in {"dockerfile", "makefile"}:
+                continue
+            data = path.read_bytes()
+            if b"\0" in data:
+                continue
+            text = data.decode("utf-8", errors="ignore")
+        except OSError:
+            continue
+        if any(valid_cpf(match.group(0)) for match in CPF_RE.finditer(text)):
+            findings.add((item, "valid-cpf-pattern"))
+        if PHONE_RE.search(text):
+            findings.add((item, "br-phone-pattern"))
+        if SENSITIVE_CONTEXT.search(item):
+            for match in EMAIL_RE.finditer(text):
+                if match.group(1).lower() not in SYNTHETIC_EMAIL_DOMAINS:
+                    findings.add((item, "non-synthetic-email-in-sensitive-context"))
+                    break
+    if findings:
+        print(f"Repository policy scan: FAIL ({len(findings)} redacted finding(s))")
+        for path, rule in sorted(findings):
+            print(f"- {path}: {rule}")
+        raise SystemExit(1)
+    print("Repository policy scan: PASS")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,53 @@
+name: Security baseline
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+          GITLEAKS_VERSION: "8.30.1"
+
+  repository-policy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Reject unsafe tracked files and high-confidence PII
+        run: python .github/scripts/repository_policy_scan.py
+
+  dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install OSV-Scanner
+        shell: bash
+        run: |
+          curl -fsSLo /tmp/osv-scanner https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64
+          echo "15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0  /tmp/osv-scanner" | sha256sum -c -
+          chmod +x /tmp/osv-scanner
+      - name: Scan dependency manifests
+        run: >-
+          /tmp/osv-scanner scan source -r --allow-no-lockfiles
+          --experimental-exclude node_modules --experimental-exclude .next
+          --experimental-exclude dist --experimental-exclude build .


### PR DESCRIPTION
Adds a no-cost repository security baseline:

- Gitleaks 8.30.1 on full history with reports/comments disabled
- OSV-Scanner 2.4.0 verified by SHA-256
- redacted policy scan for unsafe tracked credential containers and high-confidence PII
- pinned third-party Actions and read-only permissions

Validated locally: existing full-history Gitleaks and OSV audits were clean; repository policy scan and `git diff --check` pass.